### PR TITLE
Carbon update, Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2",
         "ameax/xml-validator": "^1.0",
-        "nesbot/carbon": "^2.67",
+        "nesbot/carbon": "^3.0",
         "sabre/xml": "^4.0",
         "spatie/temporary-directory": "^2.1"
     },


### PR DESCRIPTION
## Summary
- Update Carbon from version 2.67 to 3.0
- Prepare package for Laravel 12 compatibility

## Changes
- Upgraded `nesbot/carbon` dependency from `^2.67` to `^3.0` in composer.json

## Test plan
- [ ] Run composer update to install new dependencies
- [ ] Run existing test suite to ensure compatibility
- [ ] Test with Laravel 12 when available

🤖 Generated with [Claude Code](https://claude.ai/code)